### PR TITLE
polkadot-sdk: 2503-2 -> 2503-4

### DIFF
--- a/pkgs/polkadot-sdk/generic.nix
+++ b/pkgs/polkadot-sdk/generic.nix
@@ -25,13 +25,13 @@ in
 rustPlatform.buildRustPackage rec {
   inherit pname;
 
-  version = "2503-3";
+  version = "2503-4";
 
   src = fetchFromGitHub {
     owner = "paritytech";
     repo = "polkadot-sdk";
     rev = "polkadot-stable${version}";
-    hash = "sha256-RRJrHi+v5EVnlRgF0TR4VyBxMHE96v3BLs+DSd09H/c=";
+    hash = "sha256-qTW4fuJ3llAnuWPjQ0vj5izbWwchIz68jgkjNAe8J5E=";
 
     # the build process of polkadot requires a .git folder in order to determine
     # the git commit hash that is being built and add it to the version string.
@@ -53,7 +53,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-fvn2u9+RcTApF3864ebQgI06R6Vo0fQq2p/QkIeLS4k=";
+  cargoHash = "sha256-lWPESatAFkdCuBDrTyYgtcmkpmm0yZjyqd7IhIVohS4=";
 
   buildType = "production";
   buildAndTestSubdir = target;

--- a/pkgs/polkadot-sdk/generic.nix
+++ b/pkgs/polkadot-sdk/generic.nix
@@ -25,13 +25,13 @@ in
 rustPlatform.buildRustPackage rec {
   inherit pname;
 
-  version = "2503-2";
+  version = "2503-3";
 
   src = fetchFromGitHub {
     owner = "paritytech";
     repo = "polkadot-sdk";
     rev = "polkadot-stable${version}";
-    hash = "sha256-sUBUWFAJ8PwWUVSqPef0SMJcvSt+bGruTW+GmJGTLdE=";
+    hash = "sha256-RRJrHi+v5EVnlRgF0TR4VyBxMHE96v3BLs+DSd09H/c=";
 
     # the build process of polkadot requires a .git folder in order to determine
     # the git commit hash that is being built and add it to the version string.
@@ -53,7 +53,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-U3roe7rQL1BaHr3rKV1Dl7Lhjic3pZlxo2DpD9C2ong=";
+  cargoHash = "sha256-fvn2u9+RcTApF3864ebQgI06R6Vo0fQq2p/QkIeLS4k=";
 
   buildType = "production";
   buildAndTestSubdir = target;


### PR DESCRIPTION
For emergency release https://github.com/paritytech/polkadot-sdk/releases/tag/polkadot-stable2503-3 & system-wide followup https://github.com/paritytech/polkadot-sdk/releases/tag/polkadot-stable2503-4.

~Since this applicable only to Kusama (Polkadot nodes won't start), opening up as draft so any affected Kusama operators can pull from here.~

~Can't think of an elegant way to handle this temporary bifurcation, so reckon this PR should just be closed once a system-wide release is out.~